### PR TITLE
Make BSplines work with integer support points

### DIFF
--- a/src/caches/interpolation_caches.jl
+++ b/src/caches/interpolation_caches.jl
@@ -159,8 +159,8 @@ function BSplineInterpolation(u,t,d,pVecType,knotVecType)
   u, t = munge_data(u, t)
   n = length(t)
   s = zero(eltype(u))
-  p = zero(t)
-  k = zeros(eltype(t),n+d+1)
+  p = float(zero(t))
+  k = float(zeros(eltype(t),n+d+1))
   l = zeros(eltype(u),n-1)
   p[1] = zero(eltype(t))
   p[end] = one(eltype(t))
@@ -188,7 +188,7 @@ function BSplineInterpolation(u,t,d,pVecType,knotVecType)
     ridx -= 1
   end
 
-  ps = zeros(eltype(t),n-2)
+  ps = float(zeros(eltype(t),n-2))
   s = zero(eltype(t))
   for i = 2:n-1
     s += p[i]
@@ -237,8 +237,8 @@ function BSplineApprox(u,t,d,h,pVecType,knotVecType)
   u, t = munge_data(u, t)
   n = length(t)
   s = zero(eltype(u))
-  p = zero(t)
-  k = zeros(eltype(t),h+d+1)
+  p = float(zero(t))
+  k = float(zeros(eltype(t),h+d+1))
   l = zeros(eltype(u),n-1)
   p[1] = zero(eltype(t))
   p[end] = one(eltype(t))
@@ -266,7 +266,7 @@ function BSplineApprox(u,t,d,h,pVecType,knotVecType)
     ridx -= 1
   end
 
-  ps = zeros(eltype(t),n-2)
+  ps = float(zeros(eltype(t),n-2))
   s = zero(eltype(t))
   for i = 2:n-1
     s += p[i]
@@ -297,7 +297,7 @@ function BSplineApprox(u,t,d,h,pVecType,knotVecType)
   c[1] = u[1]
   c[end] = u[end]
   q = zeros(eltype(u), n)
-  N = zeros(eltype(t), n, h)
+  N = float(zeros(eltype(t), n, h))
   for i = 1:n
     N[i, :] .= spline_coefficients(h,d,k,p[i])
   end

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -181,6 +181,28 @@ A = BSplineApprox(u,t,2,4,:Uniform,:Uniform)
 @test [A(25.0), A(80.0)] ≈ [12.979802931218234, 10.914310609953178]
 @test [A(190.0), A(225.0)] ≈ [13.851245975109263, 12.963685868886575]
 
+t_int = trunc.(Int, t)
+t_float = float(t_int)
+A = BSplineInterpolation(u,t_int,2,:Uniform,:Uniform)
+B = BSplineInterpolation(u,t_float,2,:Uniform,:Uniform)
+
+@test A(25.0) == B(25.0)
+
+A = BSplineInterpolation(u,t_int,2,:ArcLen,:Average)
+B = BSplineInterpolation(u,t_float,2,:ArcLen,:Average)
+
+@test A(25.0) == B(25.0)
+
+A = BSplineApprox(u,t_int,2,4,:Uniform,:Uniform)
+B = BSplineApprox(u,t_float,2,4,:Uniform,:Uniform)
+
+@test A(25.0) == B(25.0)
+
+A = BSplineApprox(u,t_int,2,4,:ArcLen,:Average)
+B = BSplineApprox(u,t_float,2,4,:ArcLen,:Average)
+
+@test A(25.0) == B(25.0)
+
 # Loess Interpolation
 # test against Loess.jl [https://github.com/JuliaStats/Loess.jl]
 # Currently, Loess.jl is not compatible with Julia 1.0


### PR DESCRIPTION
I was just tripped up by the fact that you cannot use integer vectors as support points for the BSplines since you are getting `InexactError`s.

This fixes it by making the temporaries float vectors. Don't know whether this is sensible 🤷‍♂ 