### PR TITLE
add curidx to linearinterpolation and zerospline

### DIFF
--- a/src/caches/interpolation_caches.jl
+++ b/src/caches/interpolation_caches.jl
@@ -2,7 +2,8 @@
 struct LinearInterpolation{uType,tType,FT,T} <: AbstractInterpolation{FT,T}
   u::uType
   t::tType
-  LinearInterpolation{FT}(u,t) where FT = new{typeof(u),typeof(t),FT,eltype(u)}(u,t)
+  curidx::Ref{Int}
+  LinearInterpolation{FT}(u,t) where FT = new{typeof(u),typeof(t),FT,eltype(u)}(u,t,Ref(1))
 end
 
 function LinearInterpolation(u,t)
@@ -83,7 +84,8 @@ struct ZeroSpline{uType,tType,dirType,FT,T} <: AbstractInterpolation{FT,T}
   u::uType
   t::tType
   dir::Symbol # indicates if value to the $dir should be used for the interpolation
-  ZeroSpline{FT}(u,t,dir) where FT = new{typeof(u),typeof(t),typeof(dir),FT,eltype(u)}(u,t,dir)
+  curidx::Ref{Int}
+  ZeroSpline{FT}(u,t,dir) where FT = new{typeof(u),typeof(t),typeof(dir),FT,eltype(u)}(u,t,dir,Ref(1))
 end
 
 function ZeroSpline(u,t;dir=:left)

--- a/src/interpolation_alg/interpolation_methods.jl
+++ b/src/interpolation_alg/interpolation_methods.jl
@@ -17,7 +17,7 @@ function shortcut_index_search_last(t,T,curidx)
     ifelse(_curidx < length(T)-1 && t >= T[_curidx] && t < T[_curidx+1], _curidx,
     ifelse(_curidx < length(T)-2 && t >= T[_curidx+1] && t < T[_curidx+2],_curidx+1,
     ifelse(_curidx > 1 && t >= T[_curidx-1] && t < T[_curidx],_curidx-1,-1))))
-  if idx = -1
+  if idx == -1
     idx = max(1,searchsortedlast(T,t)
   end
   curidx[] = idx

--- a/src/interpolation_alg/interpolation_methods.jl
+++ b/src/interpolation_alg/interpolation_methods.jl
@@ -16,8 +16,10 @@ function shortcut_index_search_last(t,T,curidx)
   idx = ifelse(_curidx == length(T) && t >= T[_curidx],_curidx,
     ifelse(_curidx < length(T)-1 && t >= T[_curidx] && t < T[_curidx+1], _curidx,
     ifelse(_curidx < length(T)-2 && t >= T[_curidx+1] && t < T[_curidx+2],_curidx+1,
-    ifelse(_curidx > 1 && t >= T[_curidx-1] && t < T[_curidx],_curidx-1,
-    max(1,searchsortedlast(T,t))))))
+    ifelse(_curidx > 1 && t >= T[_curidx-1] && t < T[_curidx],_curidx-1,-1))))
+  if idx = -1
+    idx = max(1,searchsortedlast(T,t)
+  end
   curidx[] = idx
   idx
 end
@@ -40,8 +42,11 @@ function shortcut_index_search_first(t,T,curidx)
   idx = ifelse(_curidx > 1 && t >= T[_curidx-1] && t <= T[_curidx],_curidx,
     ifelse(_curidx == 1 && t <= T[1],_curidx,
     ifelse(_curidx < length(T)-1 && t >= T[_curidx] && t <= T[_curidx+1],_curidx+1,
-    ifelse(_curidx > 2 && t >= T[_curidx-2] && t <= T[_curidx-1],_curidx-1,
-    min(length(T),searchsortedfirst(T,t))))))
+    ifelse(_curidx > 2 && t >= T[_curidx-2] && t <= T[_curidx-1],_curidx-1,-1
+    ))))
+  if idx == -1
+    idx = min(length(T),searchsortedfirst(T,t))
+  end
   curidx[] = idx
   idx
 end


### PR DESCRIPTION
Avoids extra searching by keeping a current index and checking the current value before doing a full search. Maybe it's best to not do the neighbors either, and just do the current, but I went ahead and did the neighbors for now. Everything is `ifelse` since the computations are cheap, I assume that might be faster but haven't fully tested the speed yet.