### PR TITLE
Fix BSpline evaluation error on final point

### DIFF
--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -141,7 +141,7 @@ end
 function (A::BSplineInterpolation{<:AbstractVector{<:Number}})(t::Number)
   # change t into param [0 1]
   idx = searchsortedlast(A.t,t)
-  idx == 0 ? idx += 1 : nothing
+  idx == length(A.t) ? idx -= 1 : nothing
   t = A.p[idx] + (t - A.t[idx])/(A.t[idx+1] - A.t[idx]) * (A.p[idx+1] - A.p[idx])
   n = length(A.t)
   N = spline_coefficients(n,A.d,A.k,t)
@@ -156,7 +156,7 @@ end
 function (A::BSplineApprox{<:AbstractVector{<:Number}})(t::Number)
   # change t into param [0 1]
   idx = searchsortedlast(A.t,t)
-  idx == 0 ? idx += 1 : nothing
+  idx == length(A.t) ? idx -= 1 : nothing
   t = A.p[idx] + (t - A.t[idx])/(A.t[idx+1] - A.t[idx]) * (A.p[idx+1] - A.p[idx])
   n = length(A.t)
   N = spline_coefficients(A.h,A.d,A.k,t)

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -179,16 +179,19 @@ A = BSplineInterpolation(u,t,2,:Uniform,:Uniform)
 
 @test [A(25.0), A(80.0)] == [13.454197730061425, 10.305633616059845]
 @test [A(190.0), A(225.0)] == [14.07428439395079, 11.057784141519251]
+@test [A(t[1]), A(t[end])] == [u[1], u[end]]
 
 A = BSplineInterpolation(u,t,2,:ArcLen,:Average)
 
 @test [A(25.0), A(80.0)] == [13.363814458968486, 10.685201117692609]
 @test [A(190.0), A(225.0)] == [13.437481084762863, 11.367034741256463]
+@test [A(t[1]), A(t[end])] == [u[1], u[end]]
 
 A = BSplineApprox(u,t,2,4,:Uniform,:Uniform)
 
 @test [A(25.0), A(80.0)] ≈ [12.979802931218234, 10.914310609953178]
 @test [A(190.0), A(225.0)] ≈ [13.851245975109263, 12.963685868886575]
+@test [A(t[1]), A(t[end])] ≈ [u[1], u[end]]
 
 
 # Curvefit Interpolation


### PR DESCRIPTION
This fixes an error of indexing that appearead when evaluating the BSpline on the final point used for interpolation (`A(t[end])` on interpolation_tests.jl). Possibly caused when `findfirst` was substituted by `searchsortedlast`.