### PR TITLE
Skip differentiation of terms needed in SplineLayer

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataInterpolations"
 uuid = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
-version = "3.3.0"
+version = "3.3.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/DataInterpolations.jl
+++ b/src/DataInterpolations.jl
@@ -22,7 +22,7 @@ include("plot_rec.jl")
 include("derivatives.jl")
 
 function ChainRulesCore.rrule(::typeof(_interpolate), A::Union{LagrangeInterpolation,AkimaInterpolation,
-                                                               BSplineInterpolation,BSplineApprox} t::Number)
+                                                               BSplineInterpolation,BSplineApprox}, t::Number)
     interpolate_pullback(Δ) = (NO_FIELDS, DoesNotExist(), derivative(A, t) * Δ)
     return _interpolate(A, t), interpolate_pullback
 end

--- a/src/DataInterpolations.jl
+++ b/src/DataInterpolations.jl
@@ -21,7 +21,8 @@ include("interpolation_methods.jl")
 include("plot_rec.jl")
 include("derivatives.jl")
 
-function ChainRulesCore.rrule(::typeof(_interpolate), A::AbstractInterpolation, t::Number)
+function ChainRulesCore.rrule(::typeof(_interpolate), A::Union{LagrangeInterpolation,AkimaInterpolation,
+                                                               BSplineInterpolation,BSplineApprox} t::Number)
     interpolate_pullback(Δ) = (NO_FIELDS, DoesNotExist(), derivative(A, t) * Δ)
     return _interpolate(A, t), interpolate_pullback
 end


### PR DESCRIPTION
These happen to be the ones that Zygote could already handle and do not have numerical stability issues.

https://github.com/SciML/DiffEqFlux.jl/blob/e7cbc6170429c2e72b59f0bdda832845431d378f/src/spline_layer.jl#L19-L20

We should extend the rrule to include derivatives of the coefficients instead of the `DoesNotExist()` as it will decrease the complexity on the source code rewriting and ensure we get numerical stability, but for now this gets tests passing.