### PR TITLE
Register Interpolations for Symbolics

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3' # Minimum Julia version required
+          - '1.6' # Minimum Julia version required
           - '1'
 #          - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
 ChainRulesCore = "0.9.44, 0.10, 1"

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Optim = "0.19, 0.20, 0.21, 0.22, 1.0"
 RecipesBase = "0.8, 1.0"
 RecursiveArrayTools = "2"
 Reexport = "0.2, 1.0"
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataInterpolations"
 uuid = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
-version = "3.6.1"
+version = "3.7.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/DataInterpolations.jl
+++ b/src/DataInterpolations.jl
@@ -31,6 +31,13 @@ ChainRulesCore.frule((_, _, Δt), ::typeof(_interpolate), A::AbstractInterpolati
 
 (interp::AbstractInterpolation)(t::Number) = _interpolate(interp, t)
 
+import Symbolics
+Base.@pure __parameterless_type(T) = Base.typename(T).wrapper
+Base.nameof(x::AbstractInterpolation) = typeof(x)
+Base.isbinaryoperator(::Type{T}) where T <: AbstractInterpolation = false
+(interp::DataInterpolations.AbstractInterpolation)(t::Symbolics.Num) = Symbolics.SymbolicUtils.term(interp,t)
+
+
 export LinearInterpolation, QuadraticInterpolation, LagrangeInterpolation, AkimaInterpolation,
        ConstantInterpolation, QuadraticSpline, CubicSpline, BSplineInterpolation, BSplineApprox, Curvefit
 

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -16,3 +16,11 @@ A = LinearInterpolation{false}(u,t)
 for i in 1:10
   @test u[i] == A[i]
 end
+
+using Symbolics
+u = 2.0collect(1:10)
+t = 1.0collect(1:10)
+A = LinearInterpolation(u,t)
+
+@variables t
+A(t)


### PR DESCRIPTION
@yingboma do you know why the printing is weird?

```julia
julia> using Symbolics; u = 2.0collect(1:10); t = 1.0collect(1:10);

julia> A = LinearInterpolation(u,t);

julia> @variables t
1-element Vector{Num}:
 t

julia> A(t)
[2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 18.0, 20.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0](t)

julia> Symbolics.operation(A(t))
20-element LinearInterpolation{Vector{Float64}, Vector{Float64}, true, Float64}:
  2.0
  4.0
  6.0
  8.0
 10.0
  ⋮
  6.0
  7.0
  8.0
  9.0
 10.0

julia> Symbolics.arguments(A(t))
1-element Vector{Num}:
 t
```