### PR TITLE
add support for analytical integration of some interpolations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,8 +22,9 @@ julia = "1.6"
 
 [extras]
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
+QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "StableRNGs", "FiniteDifferences"]
+test = ["Test", "StableRNGs", "FiniteDifferences", "QuadGK"]

--- a/src/DataInterpolations.jl
+++ b/src/DataInterpolations.jl
@@ -20,6 +20,7 @@ include("interpolation_utils.jl")
 include("interpolation_methods.jl")
 include("plot_rec.jl")
 include("derivatives.jl")
+include("integrals.jl")
 
 function ChainRulesCore.rrule(::typeof(_interpolate), A::Union{LagrangeInterpolation,AkimaInterpolation,
                                                                BSplineInterpolation,BSplineApprox}, t::Number)

--- a/src/integrals.jl
+++ b/src/integrals.jl
@@ -1,0 +1,83 @@
+function integral(A::AbstractInterpolation, t::Number)
+    bw, fw = samples(A)
+    idx = max(1+bw, min(searchsortedlast(A.t, t), length(A.t) - fw))
+    _integral(A, idx, t)
+end
+
+function integral(A::AbstractInterpolation, t1::Number, t2::Number)
+    bw, fw = samples(A)
+    # the index less than or equal to t1
+    idx1 = max(1+bw, min(searchsortedlast(A.t, t1), length(A.t) - fw))
+    # the index less than t2
+    idx2 = max(2+bw, min(searchsortedlast(A.t, t2), length(A.t) - fw))
+    if A.t[idx2] == t2
+        idx2-=1
+    end
+    total = zero(eltype(A))
+    for idx in idx1:idx2
+        lt1 = idx == idx1 ? t1 : A.t[idx]
+        lt2 = idx == idx2 ? t2 : A.t[idx+1]
+        total += _integral(A, idx, lt2)-_integral(A, idx, lt1)
+    end
+    total
+end
+
+samples(A::LinearInterpolation{<:AbstractVector}) = (0, 1)
+function _integral(A::LinearInterpolation{<:AbstractVector}, idx::Number, t::Number)
+  t1 = A.t[idx]
+  t2 = A.t[idx+1]
+  u1 = A.u[idx]
+  u2 = A.u[idx+1]
+  t^2*(u1 - u2)/(2*t1 - 2*t2) + t*(t1*u2 - t2*u1)/(t1 - t2)
+end
+
+samples(A::ConstantInterpolation{<:AbstractVector}) = (0, 1)
+function _integral(A::ConstantInterpolation{<:AbstractVector}, idx::Number, t::Number)
+  if A.dir === :left
+    # :left means that value to the left is used for interpolation
+    return A.u[idx]*t
+  else
+    # :right means that value to the right is used for interpolation
+    return A.u[idx+1]*t
+  end
+end
+
+samples(A::QuadraticInterpolation{<:AbstractVector}) = (0, 2)
+function _integral(A::QuadraticInterpolation{<:AbstractVector}, idx::Number, t::Number)
+  t1 = A.t[idx]
+  t2 = A.t[idx+1]
+  t3 = A.t[idx+2]
+  u1 = A.u[idx]
+  u2 = A.u[idx+1]
+  u3 = A.u[idx+2]
+  (t^3*(-t1*u2 + t1*u3 + t2*u1 - t2*u3 - t3*u1 + t3*u2)/
+  (3*t1^2*t2 - 3*t1^2*t3 - 3*t1*t2^2 + 3*t1*t3^2 + 3*t2^2*t3 - 3*t2*t3^2) +
+  t^2*(t1^2*u2 - t1^2*u3 - t2^2*u1 + t2^2*u3 + t3^2*u1 - t3^2*u2)/
+  (2*t1^2*t2 - 2*t1^2*t3 - 2*t1*t2^2 + 2*t1*t3^2 + 2*t2^2*t3 - 2*t2*t3^2) +
+  t*(t1^2*t2*u3 - t1^2*t3*u2 - t1*t2^2*u3 + t1*t3^2*u2 + t2^2*t3*u1 - t2*t3^2*u1)/
+  (t1^2*t2 - t1^2*t3 - t1*t2^2 + t1*t3^2 + t2^2*t3 - t2*t3^2))
+end
+
+samples(A::QuadraticSpline{<:AbstractVector}) = (0, 1)
+function _integral(A::QuadraticSpline{<:AbstractVector}, idx::Number, t::Number)
+  t1 = A.t[idx]
+  t2 = A.t[idx+1]
+  u1 = A.u[idx]
+  z1 = A.z[idx]
+  z2 = A.z[idx+1]
+  t^3*(z1 - z2)/(6*t1 - 6*t2) + t^2*(t1*z2 - t2*z1)/(2*t1 - 2*t2) + t*(-t1^2*z1 - t1^2*z2 + 2*t1*t2*z1 + 2*t1*u1 - 2*t2*u1)/(2*t1 - 2*t2)
+end
+
+samples(A::CubicSpline{<:AbstractVector}) = (0, 1)
+function _integral(A::CubicSpline{<:AbstractVector}, idx::Number, t::Number)
+  t1 = A.t[idx]
+  t2 = A.t[idx+1]
+  u1 = A.u[idx]
+  u2 = A.u[idx+1]
+  z1 = A.z[idx]
+  z2 = A.z[idx+1]
+  h2 = A.h[idx+1]
+  (t^4*(-z1 + z2)/(24*h2) + t^3*(-t1*z2 + t2*z1)/(6*h2) +
+  t^2*(h2^2*z1 - h2^2*z2 + 3*t1^2*z2 - 3*t2^2*z1 - 6*u1 + 6*u2)/(12*h2) +
+  t*(h2^2*t1*z2 - h2^2*t2*z1 - t1^3*z2 - 6*t1*u2 + t2^3*z1 + 6*t2*u1)/(6*h2))
+end

--- a/test/integral_tests.jl
+++ b/test/integral_tests.jl
@@ -1,0 +1,44 @@
+using DataInterpolations, Test
+using QuadGK
+using DataInterpolations: integral
+
+
+function test_integral(func, tspan, name::String)
+  t1 = minimum(tspan)
+  t2 = maximum(tspan)
+  @testset "$name" begin
+    qint, err = quadgk(func, t1, t2)
+    aint = integral(func, t1, t2)
+    @test isapprox(qint, aint, atol=1e-8)
+  end
+end
+
+# Linear Interpolation
+u = 2.0collect(1:10)
+t = 1.0collect(1:10)
+A = LinearInterpolation(u,t)
+
+test_integral(A, t, "Linear Interpolation (Vector)")
+
+# Quadratic Interpolation
+u = [1.0, 4.0, 9.0, 16.0]
+t = [1.0, 2.0, 3.0, 4.0]
+A = QuadraticInterpolation(u,t)
+
+test_integral(A, t, "Quadratic Interpolation (Vector)")
+
+# QuadraticSpline Interpolation
+u = [0.0, 1.0, 3.0]
+t = [-1.0, 0.0, 1.0]
+
+A = QuadraticSpline(u,t)
+
+test_integral(A, t, "Quadratic Interpolation")
+
+# CubicSpline Interpolation
+u = [0.0, 1.0, 3.0]
+t = [-1.0, 0.0, 1.0]
+
+A = CubicSpline(u,t)
+
+test_integral(A, t, "Cubic Spline Interpolation")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,3 +3,4 @@ using DataInterpolations, Test
 @testset "Interface" begin include("interface.jl") end
 @testset "Interpolation Tests" begin include("interpolation_tests.jl") end
 @testset "Derivative Tests" begin include("derivative_tests.jl") end
+@testset "Integral Tests" begin include("integral_tests.jl") end


### PR DESCRIPTION
DataInterpolations already has support for computing the analytical derivative at any given point. This PR is a first step towards providing the same for integration.

I've computed the analytical integrals of the interpolation functions with an ungodly mix of Symbolics, Sympy, and copy-pasting, since Symbolics does [not yet](https://julialang.org/jsoc/gsoc/symbolics/#symbolic_integration) have a heuristic symbolical integration package like Sympy does, so was only used to extract the equations from the existing code.

This PR only adds integrals for a subset of the supported interpolations that seemed useful and easy to do. A future PR could extend this to more interpolations, but first I'll go back and put this functionality through its paces in CedarWaves.