### PR TITLE
add append! for online interpolation

### DIFF
--- a/src/DataInterpolations.jl
+++ b/src/DataInterpolations.jl
@@ -22,6 +22,7 @@ include("interpolation_methods.jl")
 include("plot_rec.jl")
 include("derivatives.jl")
 include("integrals.jl")
+include("online.jl")
 
 function ChainRulesCore.rrule(::typeof(_interpolate),
                               A::Union{LagrangeInterpolation,AkimaInterpolation,

--- a/src/online.jl
+++ b/src/online.jl
@@ -1,0 +1,22 @@
+import Base: append!
+
+function append!(di::LinearInterpolation{U, T}, u::U, t::T) where {U, T}
+  u, t = munge_data(u, t)
+  append!(di.u, u)
+  append!(di.t, t)
+  di
+end
+
+function append!(di::QuadraticInterpolation{U, T}, u::U, t::T) where {U, T}
+  u, t = munge_data(u, t)
+  append!(di.u, u)
+  append!(di.t, t)
+  di
+end
+
+function append!(di::ConstantInterpolation{U, T}, u::U, t::T) where {U, T}
+  u, t = munge_data(u, t)
+  append!(di.u, u)
+  append!(di.t, t)
+  di
+end

--- a/src/online.jl
+++ b/src/online.jl
@@ -1,4 +1,22 @@
-import Base: append!
+import Base: append!, push!
+
+function push!(di::LinearInterpolation{U, T}, u::eltype(U), t::eltype(T)) where {U, T}
+  push!(di.u, u)
+  push!(di.t, t)
+  di
+end
+
+function push!(di::QuadraticInterpolation{U, T}, u::eltype(U), t::eltype(T)) where {U, T}
+  push!(di.u, u)
+  push!(di.t, t)
+  di
+end
+
+function push!(di::ConstantInterpolation{U, T}, u::eltype(U), t::eltype(T)) where {U, T}
+  push!(di.u, u)
+  push!(di.t, t)
+  di
+end
 
 function append!(di::LinearInterpolation{U, T}, u::U, t::T) where {U, T}
   u, t = munge_data(u, t)

--- a/test/online_tests.jl
+++ b/test/online_tests.jl
@@ -4,7 +4,7 @@ t = [1,2,3]
 u = [0, 1, 0]
 
 for di in [LinearInterpolation, QuadraticInterpolation, ConstantInterpolation]
-    li = LinearInterpolation(copy(u), copy(t))
+    li = di(copy(u), copy(t))
     append!(li, u, t)
-    @test li == LinearInterpolation(vcat(u, u), vcat(t, t))
+    @test li == di(vcat(u, u), vcat(t, t))
 end

--- a/test/online_tests.jl
+++ b/test/online_tests.jl
@@ -7,4 +7,8 @@ for di in [LinearInterpolation, QuadraticInterpolation, ConstantInterpolation]
     li = di(copy(u), copy(t))
     append!(li, u, t)
     @test li == di(vcat(u, u), vcat(t, t))
+
+    li = di(copy(u), copy(t))
+    push!(li, 4, 1)
+    @test li == di(vcat(u, 1), vcat(t, 4))
 end

--- a/test/online_tests.jl
+++ b/test/online_tests.jl
@@ -1,0 +1,10 @@
+using DataInterpolations, Test
+
+t = [1,2,3]
+u = [0, 1, 0]
+
+for di in [LinearInterpolation, QuadraticInterpolation, ConstantInterpolation]
+    li = LinearInterpolation(copy(u), copy(t))
+    append!(li, u, t)
+    @test li == LinearInterpolation(vcat(u, u), vcat(t, t))
+end

--- a/test/online_tests.jl
+++ b/test/online_tests.jl
@@ -9,6 +9,6 @@ for di in [LinearInterpolation, QuadraticInterpolation, ConstantInterpolation]
     @test li == di(vcat(u, u), vcat(t, t))
 
     li = di(copy(u), copy(t))
-    push!(li, 4, 1)
+    push!(li, 1, 4)
     @test li == di(vcat(u, 1), vcat(t, 4))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,3 +4,4 @@ using DataInterpolations, Test
 @testset "Interpolation Tests" begin include("interpolation_tests.jl") end
 @testset "Derivative Tests" begin include("derivative_tests.jl") end
 @testset "Integral Tests" begin include("integral_tests.jl") end
+@testset "Online Tests" begin include("online_tests.jl") end


### PR DESCRIPTION
This adds an `append!` implementation for a few simple interpolations so that they can be used in an online context.

It should be possible to implement this for a few more interpolations that are not global, such as Akima.
But I'll just put this out there to make sure I'm going in the right direction before doing tricky things to make online Akima work and then have to do it again based on feedback.

Some things I'm not totally sure about:

- maybe we should implement `push!`
- maybe the type bounds are too tight now
- it seems very eager to call the `AbstractVector` method and complain there is no `resize!` method.
- lagrange has an immutable length field
- which methods are amenable to appending data