### PR TITLE
LagrangeInterpolation, QuadraticSpline, CubicSpline for data with multiple channels

### DIFF
--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -135,7 +135,7 @@ function derivative(A::ConstantInterpolation{<:AbstractMatrix}, t::Number)
 end
 
 # QuadraticSpline Interpolation
-function derivative(A::QuadraticSpline{<:AbstractVector{<:Number}}, t::Number)
+function derivative(A::QuadraticSpline{<:AbstractVector}, t::Number)
   i = searchsortedfirst(A.t, t)
   i == 1 ? i += 1 : nothing
   σ = 1//2 * (A.z[i] - A.z[i - 1]) / (A.t[i] - A.t[i - 1])
@@ -143,7 +143,7 @@ function derivative(A::QuadraticSpline{<:AbstractVector{<:Number}}, t::Number)
 end
 
 # CubicSpline Interpolation
-function derivative(A::CubicSpline{<:AbstractVector{<:Number}}, t::Number)
+function derivative(A::CubicSpline{<:AbstractVector}, t::Number)
   i = searchsortedfirst(A.t, t)
   isnothing(i) ? i = length(A.t) - 1 : i -= 1
   i == 0 ? i += 1 : nothing

--- a/src/integrals.jl
+++ b/src/integrals.jl
@@ -23,7 +23,7 @@ function integral(A::AbstractInterpolation, t1::Number, t2::Number)
 end
 
 samples(A::LinearInterpolation{<:AbstractVector}) = (0, 1)
-function _integral(A::LinearInterpolation{<:AbstractVector}, idx::Number, t::Number)
+function _integral(A::LinearInterpolation{<:AbstractVector{<:Number}}, idx::Number, t::Number)
   t1 = A.t[idx]
   t2 = A.t[idx+1]
   u1 = A.u[idx]
@@ -43,7 +43,7 @@ function _integral(A::ConstantInterpolation{<:AbstractVector}, idx::Number, t::N
 end
 
 samples(A::QuadraticInterpolation{<:AbstractVector}) = (0, 2)
-function _integral(A::QuadraticInterpolation{<:AbstractVector}, idx::Number, t::Number)
+function _integral(A::QuadraticInterpolation{<:AbstractVector{<:Number}}, idx::Number, t::Number)
   t1 = A.t[idx]
   t2 = A.t[idx+1]
   t3 = A.t[idx+2]
@@ -58,8 +58,8 @@ function _integral(A::QuadraticInterpolation{<:AbstractVector}, idx::Number, t::
   (t1^2*t2 - t1^2*t3 - t1*t2^2 + t1*t3^2 + t2^2*t3 - t2*t3^2))
 end
 
-samples(A::QuadraticSpline{<:AbstractVector}) = (0, 1)
-function _integral(A::QuadraticSpline{<:AbstractVector}, idx::Number, t::Number)
+samples(A::QuadraticSpline{<:AbstractVector{<:Number}}) = (0, 1)
+function _integral(A::QuadraticSpline{<:AbstractVector{<:Number}}, idx::Number, t::Number)
   t1 = A.t[idx]
   t2 = A.t[idx+1]
   u1 = A.u[idx]
@@ -68,8 +68,8 @@ function _integral(A::QuadraticSpline{<:AbstractVector}, idx::Number, t::Number)
   t^3*(z1 - z2)/(6*t1 - 6*t2) + t^2*(t1*z2 - t2*z1)/(2*t1 - 2*t2) + t*(-t1^2*z1 - t1^2*z2 + 2*t1*t2*z1 + 2*t1*u1 - 2*t2*u1)/(2*t1 - 2*t2)
 end
 
-samples(A::CubicSpline{<:AbstractVector}) = (0, 1)
-function _integral(A::CubicSpline{<:AbstractVector}, idx::Number, t::Number)
+samples(A::CubicSpline{<:AbstractVector{<:Number}}) = (0, 1)
+function _integral(A::CubicSpline{<:AbstractVector{<:Number}}, idx::Number, t::Number)
   t1 = A.t[idx]
   t2 = A.t[idx+1]
   u1 = A.u[idx]

--- a/src/interpolation_caches.jl
+++ b/src/interpolation_caches.jl
@@ -29,7 +29,7 @@ struct LagrangeInterpolation{uType,tType,FT,T,bcacheType} <: AbstractInterpolati
   n::Int
   bcache::bcacheType
   function LagrangeInterpolation{FT}(u,t,n) where FT
-    bcache = zeros(eltype(u),n+1)
+    bcache = zeros(eltype(u[1]),n+1)
     fill!(bcache, NaN)
     new{typeof(u),typeof(t),FT,eltype(u),typeof(bcache)}(u,t,n,bcache)
   end

--- a/src/interpolation_caches.jl
+++ b/src/interpolation_caches.jl
@@ -128,7 +128,7 @@ function QuadraticSpline(u::uType,t) where {uType<:AbstractVector}
   d_tmp = ones(eltype(t),s)
   du = zeros(eltype(t),s-1)
   tA = Tridiagonal(dl,d_tmp,du)
-  d_ = map(i -> i == 1 ? zeros(size(u[1])) : 2//1 * (u[i] - u[i-1])/(t[i] - t[i-1]), 1:s)
+  d_ = map(i -> i == 1 ? zeros(eltype(t),size(u[1])) : 2//1 * (u[i] - u[i-1])/(t[i] - t[i-1]), 1:s)
   d = transpose(reshape(reduce(hcat, d_), :, s))
   z_ = reshape(transpose(tA\d), size(u[1])..., :)
   z = [z_s for z_s in eachslice(z_, dims=ndims(z_))]
@@ -165,7 +165,7 @@ function CubicSpline(u::uType,t) where {uType<:AbstractVector}
   d_tmp = 2 .* (h[1:n+1] .+ h[2:n+2])
   du = h[2:n+1]
   tA = Tridiagonal(dl,d_tmp,du)
-  d_ = map(i -> i == 1 || i == n + 1 ? zeros(size(u[1])) : 6(u[i+1] - u[i]) / h[i+1] - 6(u[i] - u[i-1]) / h[i], 1:n+1)
+  d_ = map(i -> i == 1 || i == n + 1 ? zeros(eltype(t),size(u[1])) : 6(u[i+1] - u[i]) / h[i+1] - 6(u[i] - u[i-1]) / h[i], 1:n+1)
   d = transpose(reshape(reduce(hcat, d_), :, n+1))
   z_ = reshape(transpose(tA\d), size(u[1])...,:)
   z = [z_s for z_s in eachslice(z_, dims=ndims(z_))]

--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -117,7 +117,7 @@ function _interpolate(A::ConstantInterpolation{<:AbstractMatrix}, t::Number)
 end
 
 # QuadraticSpline Interpolation
-function _interpolate(A::QuadraticSpline{<:AbstractVector{<:Number}}, t::Number)
+function _interpolate(A::QuadraticSpline{<:AbstractVector}, t::Number)
   i = min(max(2, searchsortedfirst(A.t, t)), length(A.t))
   Cᵢ = A.u[i-1]
   σ = 1//2 * (A.z[i] - A.z[i-1])/(A.t[i] - A.t[i-1])
@@ -125,7 +125,7 @@ function _interpolate(A::QuadraticSpline{<:AbstractVector{<:Number}}, t::Number)
 end
 
 # CubicSpline Interpolation
-function _interpolate(A::CubicSpline{<:AbstractVector{<:Number}}, t::Number)
+function _interpolate(A::CubicSpline{<:AbstractVector}, t::Number)
   i = max(1, min(searchsortedlast(A.t, t), length(A.t) - 1))
   I = A.z[i] * (A.t[i+1] - t)^3 / (6A.h[i+1]) + A.z[i+1] * (t - A.t[i])^3 / (6A.h[i+1])
   C = (A.u[i+1]/A.h[i+1] - A.z[i+1]*A.h[i+1]/6)*(t - A.t[i])

--- a/test/derivative_tests.jl
+++ b/test/derivative_tests.jl
@@ -53,6 +53,20 @@ A = LagrangeInterpolation(u,t)
 
 test_derivatives(A, t, "Lagrange Interpolation (Matrix)")
 
+# Lagrange Interpolation
+u = [[1.0, 4.0, 9.0], [3.0, 7.0, 4.0], [5.0, 4.0, 1.0]]
+t = [1.0, 2.0, 3.0]
+A = LagrangeInterpolation(u,t)
+
+test_derivatives(A, t, "Lagrange Interpolation (Vector of Vectors)")
+
+# Lagrange Interpolation
+u = [[3.0 1.0 4.0; 1.0 5.0 9.0], [2.0 6.0 5.0; 3.0 5.0 8.0], [9.0 7.0 9.0; 3.0 2.0 3.0]]
+t = [1.0, 2.0, 3.0]
+A = LagrangeInterpolation(u,t)
+
+test_derivatives(A, t, "Lagrange Interpolation (Vector of Matrices)")
+
 # Akima Interpolation
 u = [0.0, 2.0, 1.0, 3.0, 2.0, 6.0, 5.5, 5.5, 2.7, 5.1, 3.0]
 t = collect(0.0:10.0)
@@ -66,7 +80,23 @@ t = [-1.0, 0.0, 1.0]
 
 A = QuadraticSpline(u,t)
 
-test_derivatives(A, t, "Quadratic Interpolation")
+test_derivatives(A, t, "Quadratic Interpolation (Vector)")
+
+# QuadraticSpline Interpolation
+u = [[1.0, 2.0, 9.0], [3.0, 7.0, 5.0], [5.0, 4.0, 1.0]]
+t = [-1.0, 0.0, 1.0]
+
+A = QuadraticSpline(u,t)
+
+test_derivatives(A, t, "Quadratic Interpolation (Vector of Vectors)")
+
+# QuadraticSpline Interpolation
+u = [[1.0 4.0 9.0; 5.0 9.0 2.0], [3.0 7.0 4.0; 6.0 5.0 3.0], [5.0 4.0 1.0; 2.0 3.0 8.0]]
+t = [-1.0, 0.0, 1.0]
+
+A = QuadraticSpline(u,t)
+
+test_derivatives(A, t, "Quadratic Interpolation (Vector of Matrices)")
 
 # CubicSpline Interpolation
 u = [0.0, 1.0, 3.0]
@@ -74,7 +104,23 @@ t = [-1.0, 0.0, 1.0]
 
 A = CubicSpline(u,t)
 
-test_derivatives(A, t, "Cubic Spline Interpolation")
+test_derivatives(A, t, "Cubic Spline Interpolation (Vector)")
+
+# CubicSpline Interpolation
+u = [[1.0, 2.0, 9.0], [3.0, 7.0, 5.0], [5.0, 4.0, 1.0]]
+t = [-1.0, 0.0, 1.0]
+
+A = CubicSpline(u,t)
+
+test_derivatives(A, t, "Cubic Spline Interpolation (Vector of Vectors)")
+
+# CubicSpline Interpolation
+u = [[1.0 4.0 9.0; 5.0 9.0 2.0], [3.0 7.0 4.0; 6.0 5.0 3.0], [5.0 4.0 1.0; 2.0 3.0 8.0]]
+t = [-1.0, 0.0, 1.0]
+
+A = CubicSpline(u,t)
+
+test_derivatives(A, t, "Cubic Spline Interpolation (Vector of Matrices)")
 
 # BSpline Interpolation and Approximation
 t = [0,62.25,109.66,162.66,205.8,252.3]

--- a/test/integral_tests.jl
+++ b/test/integral_tests.jl
@@ -33,7 +33,7 @@ t = [-1.0, 0.0, 1.0]
 
 A = QuadraticSpline(u,t)
 
-test_integral(A, t, "Quadratic Interpolation")
+test_integral(A, t, "Quadratic Interpolation (Vector)")
 
 # CubicSpline Interpolation
 u = [0.0, 1.0, 3.0]
@@ -41,4 +41,4 @@ t = [-1.0, 0.0, 1.0]
 
 A = CubicSpline(u,t)
 
-test_integral(A, t, "Cubic Spline Interpolation")
+test_integral(A, t, "Cubic Spline Interpolation (Vector)")

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -22,6 +22,23 @@ using StableRNGs
     @test A(0)        == [0.0, 0.0]
     @test A(5.5)      == [11.0, 16.5]
     @test A(11)       == [22, 33]
+
+    x = 1:10
+    y = 2:4
+    u_= x' .* y
+    u = [u_[:,i] for i = 1:size(u_,2)]
+    A = LinearInterpolation(u,t)
+    @test A(0)        == [0.0, 0.0, 0.0]
+    @test A(5.5)      == [11.0, 16.5, 22.0]
+    @test A(11)       == [22.0, 33.0, 44.0]
+
+    u = [u_[:,i:i+1] for i = 1:2:10]
+    t = 1.0collect(2:2:10)
+    A = LinearInterpolation(u,t)
+
+    @test A(0)        == [-2.0 0.0; -3.0 0.0; -4.0 0.0]
+    @test A(3)        == [4.0 6.0; 6.0 9.0; 8.0 12.0]
+    @test A(5)        == [8.0 10.0; 12.0 15.0; 16.0 20.0]
 end
 
 @testset "Quadratic Interpolation" begin
@@ -41,7 +58,7 @@ end
     u = [1.0 4.0 9.0 16.0; 1.0 4.0 9.0 16.0]
     A = QuadraticInterpolation(u,t)
 
-  for (_t, _u) in zip(t, eachcol(u))
+    for (_t, _u) in zip(t, eachcol(u))
         @test A(_t) == _u
     end
     @test A(0.0) == [0.0  ,  0.0 ]
@@ -49,6 +66,23 @@ end
     @test A(2.5) == [6.25 ,  6.25]
     @test A(3.5) == [12.25, 12.25]
     @test A(5.0) == [25.0 , 25.0 ]
+
+    u_= [1.0, 4.0, 9.0, 16.0]' .* ones(5)
+    u = [u_[:,i] for i = 1:size(u_,2)]
+    A = QuadraticInterpolation(u,t)
+    @test A(0)   == zeros(5)
+    @test A(1.5) == 2.25 * ones(5)
+    @test A(2.5) == 6.25 * ones(5)
+    @test A(3.5) == 12.25 * ones(5)
+    @test A(5.0) == 25.0 * ones(5)
+
+    u = [repeat(u[i], 1, 3) for i=1:4]
+    A = QuadraticInterpolation(u,t)
+    @test A(0)   == zeros(5, 3)
+    @test A(1.5) == 2.25 * ones(5, 3)
+    @test A(2.5) == 6.25 * ones(5, 3)
+    @test A(3.5) == 12.25 * ones(5, 3)
+    @test A(5.0) == 25.0 * ones(5, 3)
 end
 
 @testset "Lagrange Interpolation" begin
@@ -73,6 +107,30 @@ end
     @test A(2.0) == [4.0,4.0]
     @test A(1.5) ≈ [2.25,2.25]
     @test A(3.5) ≈ [12.25,12.25]
+
+    u_= [1.0, 4.0, 9.0]' .* ones(4)
+    u = [u_[:,i] for i = 1:size(u_,2)]
+    t = [1.0, 2.0, 3.0]
+    A = LagrangeInterpolation(u,t)
+
+    @test A(2.0) == 4.0 * ones(4)
+    @test A(1.5) == 2.25 * ones(4)
+
+    u_= [1.0, 8.0, 27.0, 64.0]' .* ones(4)
+    u = [u_[:,i] for i = 1:size(u_,2)]
+    t = [1.0, 2.0, 3.0, 4.0]
+    A = LagrangeInterpolation(u,t)
+
+    @test A(2.0) == 8.0 * ones(4)
+    @test A(1.5) ≈ 3.375 * ones(4)
+    @test A(3.5) ≈ 42.875 * ones(4)
+
+    u = [repeat(u[i], 1, 3) for i=1:4]
+    A = LagrangeInterpolation(u,t)
+
+    @test A(2.0) == 8.0 * ones(4, 3)
+    @test A(1.5) ≈ 3.375 * ones(4, 3)
+    @test A(3.5) ≈ 42.875 * ones(4, 3)
 end
 
 @testset "Akima Interpolation" begin
@@ -150,6 +208,60 @@ end
         @test A(4.0) == u[:,1]
         @test A(4.5) == u[:,1]
     end
+
+    @testset "Vector of Vectors case" for u in
+        [[[1.0, 2.0], [0.0, 1.0], [1.0, 2.0], [0.0, 1.0]], 
+        [["B", "C"], ["A", "B"], ["B", "C"], ["A", "B"]]]
+
+        A = ConstantInterpolation(u, t, dir=:right)
+        @test A(0.5) == u[1]
+        @test A(1.0) == u[1]
+        @test A(1.5) == u[2]
+        @test A(2.0) == u[2]
+        @test A(2.5) == u[3]
+        @test A(3.0) == u[3]
+        @test A(3.5) == u[4]
+        @test A(4.0) == u[4]
+        @test A(4.5) == u[4]
+
+        A = ConstantInterpolation(u, t) # dir=:left is default
+        @test A(0.5) == u[1]
+        @test A(1.0) == u[1]
+        @test A(1.5) == u[1]
+        @test A(2.0) == u[2]
+        @test A(2.5) == u[2]
+        @test A(3.0) == u[3]
+        @test A(3.5) == u[3]
+        @test A(4.0) == u[4]
+        @test A(4.5) == u[4]
+    end
+
+    @testset "Vector of Matrices case" for u in
+        [[[1.0 2.0; 1.0 2.0], [0.0 1.0; 0.0 1.0], [1.0 2.0; 1.0 2.0], [0.0 1.0; 0.0 1.0]], 
+        [["B" "C"; "B" "C"], ["A" "B"; "A" "B"], ["B" "C"; "B" "C"], ["A" "B"; "A" "B"]]]
+
+        A = ConstantInterpolation(u, t, dir=:right)
+        @test A(0.5) == u[1]
+        @test A(1.0) == u[1]
+        @test A(1.5) == u[2]
+        @test A(2.0) == u[2]
+        @test A(2.5) == u[3]
+        @test A(3.0) == u[3]
+        @test A(3.5) == u[4]
+        @test A(4.0) == u[4]
+        @test A(4.5) == u[4]
+
+        A = ConstantInterpolation(u, t) # dir=:left is default
+        @test A(0.5) == u[1]
+        @test A(1.0) == u[1]
+        @test A(1.5) == u[1]
+        @test A(2.0) == u[2]
+        @test A(2.5) == u[2]
+        @test A(3.0) == u[3]
+        @test A(3.5) == u[3]
+        @test A(4.0) == u[4]
+        @test A(4.5) == u[4]
+    end
 end
 
 @testset "QuadraticSpline Interpolation" begin
@@ -169,6 +281,21 @@ end
     @test A(-0.5) == P₁(-0.5)
     @test A(0.7)  == P₂( 0.7)
     @test A(2.0)  == P₂( 2.0)
+
+    u_= [0.0, 1.0, 3.0]' .* ones(4)
+    u = [u_[:,i] for i = 1:size(u_,2)]
+    A = QuadraticSpline(u,t)
+    @test A(-2.0) == P₁(-2.0) * ones(4)
+    @test A(-0.5) == P₁(-0.5) * ones(4)
+    @test A(0.7)  == P₂( 0.7) * ones(4)
+    @test A(2.0)  == P₂( 2.0) * ones(4)
+
+    u = [repeat(u[i], 1, 3) for i=1:3]
+    A = QuadraticSpline(u,t)
+    @test A(-2.0) == P₁(-2.0) * ones(4, 3)
+    @test A(-0.5) == P₁(-0.5) * ones(4, 3)
+    @test A(0.7)  == P₂( 0.7) * ones(4, 3)
+    @test A(2.0)  == P₂( 2.0) * ones(4, 3)
 end
 
 
@@ -190,6 +317,25 @@ end
     end
     for x in (0.3, 0.5, 1.5)
         @test A(x) ≈ P₂(x)
+    end
+
+    u_= [0.0, 1.0, 3.0]' .* ones(4)
+    u = [u_[:,i] for i = 1:size(u_,2)]
+    A = CubicSpline(u,t)
+    for x in (-1.5, -0.5, -0.7)
+        @test A(x) ≈ P₁(x) * ones(4)
+    end
+    for x in (0.3, 0.5, 1.5)
+        @test A(x) ≈ P₂(x) * ones(4)
+    end
+
+    u = [repeat(u[i], 1, 3) for i=1:3]
+    A = CubicSpline(u,t)
+    for x in (-1.5, -0.5, -0.7)
+        @test A(x) ≈ P₁(x) * ones(4, 3)
+    end
+    for x in (0.3, 0.5, 1.5)
+        @test A(x) ≈ P₂(x) * ones(4, 3)
     end
 end
 


### PR DESCRIPTION
Hello,

In using `DataInterpolations.jl` for my own application, I noticed that while `ConstantInterpolation`, `LinearInterpolation` and `QuadraticInterpolation` allow, for example:

```julia
u = [randn(4), randn(4), randn(4), randn(4), randn(4), randn(4)]
t = [0.0, 62.25, 109.66, 162.66, 205.8, 252.3]
A = ConstantInterpolation(u,t) # or LinearInterpolation(u,t) or QuadraticInterpolation(u,t)
```

or 

```julia
u = [randn(4,5), randn(4,5), randn(4,5), randn(4,5), randn(4,5), randn(4,5)]
t = [0.0, 62.25, 109.66, 162.66, 205.8, 252.3]
A = ConstantInterpolation(u,t) # or LinearInterpolation(u,t) or QuadraticInterpolation(u,t)
```

, `LagrangeInterpolation`, `QuadraticSpline`, `CubicSpline` do not allow this.

In this pull request, I modified these three functions so that `u` similar to the above examples are possible. [An implementation of neural CDE in Julia](https://github.com/SciML/DiffEqFlux.jl/issues/408) does the above with `DataInterpolations.jl` (although with `QuadraticInterpolation`).

Preliminary tests of `LagrangeInterpolation`, `QuadraticSpline`, `CubicSpline` on some variants of the above examples seem to pass.

Please let me know what you think of the changes!