### PR TITLE
Add NaN support for 1D LinearInterpolation Fix #113

### DIFF
--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -1,9 +1,13 @@
 # Linear Interpolation
 function _interpolate(A::LinearInterpolation{<:AbstractVector}, t::Number)
-  idx = max(1, min(searchsortedlast(A.t, t), length(A.t) - 1))
-  θ = (t - A.t[idx])/(A.t[idx + 1] - A.t[idx])
-  return (1 - θ)*A.u[idx] + θ*A.u[idx+1]
-end
+    idx = max(1, min(searchsortedlast(A.t, t), length(A.t) - 1))
+    t1, t2 = A.t[idx], A.t[idx+1]
+    u1, u2 = A.u[idx], A.u[idx+1]
+    t == t1 && return u1 # Return exact value if no interpolation needed (eg when NaN at t2)
+    t == t2 && return u2 # ... (eg when NaN at t1)
+    θ = (t - t1)/(t2 - t1)
+    return (1 - θ)*u1 + θ*u2
+  end
 
 function _interpolate(A::LinearInterpolation{<:AbstractMatrix}, t::Number)
   idx = max(1, min(searchsortedlast(A.t, t), length(A.t) - 1))

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -22,6 +22,48 @@ using StableRNGs
     @test A(0)        == [0.0, 0.0]
     @test A(5.5)      == [11.0, 16.5]
     @test A(11)       == [22, 33]
+
+        # with NaNs (#113)
+        u = [NaN, 1.0, 2.0, 3.0]
+        t = 1:4
+        A = LinearInterpolation(u, t)
+        @test isnan(A(1.0))
+        @test A(2.0) == 1.0
+        @test A(2.5) == 1.5
+        @test A(3.0) == 2.0
+        @test A(4.0) == 3.0
+
+        u = [0.0, NaN, 2.0, 3.0]
+        A = LinearInterpolation(u, t)
+        @test A(1.0) == 0.0
+        @test isnan(A(2.0))
+        @test isnan(A(2.5))
+        @test A(3.0) == 2.0
+        @test A(4.0) == 3.0
+
+        u = [0.0, NaN, 2.0, 3.0]
+        A = LinearInterpolation(u, t)
+        @test A(1.0) == 0.0
+        @test isnan(A(2.0))
+        @test isnan(A(2.5))
+        @test A(3.0) == 2.0
+        @test A(4.0) == 3.0
+
+        u = [0.0, 1.0, NaN, 3.0]
+        A = LinearInterpolation(u, t)
+        @test A(1.0) == 0.0
+        @test A(2.0) == 1.0
+        @test isnan(A(2.5))
+        @test isnan(A(3.0))
+        @test A(4.0) == 3.0
+
+        u = [0.0, 1.0, 2.0, NaN]
+        A = LinearInterpolation(u, t)
+        @test A(1.0) == 0.0
+        @test A(2.0) == 1.0
+        @test A(3.0) == 2.0
+        @test isnan(A(3.5))
+        @test isnan(A(4.0))
 end
 
 @testset "Quadratic Interpolation" begin


### PR DESCRIPTION
Ran some benchmarks using a uniform step time and got 419 us and when using random time values (sorted) got 421 us so I don't see a noticable slowdown.