### PR TITLE
Fix type stability issue with linear interpolation #113

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataInterpolations"
 uuid = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
-version = "3.9.0"
+version = "3.9.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -24,9 +24,10 @@ julia = "1.6"
 
 [extras]
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "StableRNGs", "FiniteDifferences", "QuadGK"]
+test = ["Test", "StableRNGs", "FiniteDifferences", "QuadGK", "ForwardDiff"]

--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -1,17 +1,13 @@
 # Linear Interpolation
-function __interpolate(u1, u2, t1, t2, t)
-    θ = (t - t1)/(t2 - t1)
-    (1 - θ)*u1 + θ*u2
-end
 function _interpolate(A::LinearInterpolation{<:AbstractVector}, t::Number)
     idx = max(1, min(searchsortedlast(A.t, t), length(A.t) - 1))
     t1, t2 = A.t[idx], A.t[idx+1]
     u1, u2 = A.u[idx], A.u[idx+1]
-    # For type stability of fast paths:
-    T = Core.Compiler.return_type(__interpolate, Tuple{typeof(u1), typeof(u2), typeof(t1), typeof(t2), typeof(t)})
-    t == t1 && return T(u1) # Return exact value if no interpolation needed (eg when NaN at t2)
-    t == t2 && return T(u2) # ... (eg when NaN at t1)
-    __interpolate(u1, u2, t1, t2, t)
+    θ = (t - t1)/(t2 - t1)
+    val = (1 - θ)*u1 + θ*u2
+    t == t1 && return oftype(val, u1) # Return exact value if no interpolation needed (eg when NaN at t2)
+    t == t2 && return oftype(val, u2) # ... (eg when NaN at t1)
+    val
 end
 
 function _interpolate(A::LinearInterpolation{<:AbstractMatrix}, t::Number)

--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -1,7 +1,8 @@
 # Linear Interpolation
 function _interpolate(A::LinearInterpolation{<:AbstractVector}, t::Number)
     if isnan(t)
-        t1 = t2 = eltype(A.t)(NaN)
+        # For correct derivative with NaN
+        t1 = t2 = one(eltype(A.t))
         u1 = u2 = one(eltype(A.u))
     else
         idx = max(1, min(searchsortedlast(A.t, t), length(A.t) - 1))
@@ -10,7 +11,7 @@ function _interpolate(A::LinearInterpolation{<:AbstractVector}, t::Number)
     end
     θ = (t - t1)/(t2 - t1)
     val = (1 - θ)*u1 + θ*u2
-    # Note: The following is limited to when val is NaN as to not change the derivative.
+    # Note: The following is limited to when val is NaN as to not change the derivative of exact points.
     t == t1 && isnan(val) && return oftype(val, u1) # Return exact value if no interpolation needed (eg when NaN at t2)
     t == t2 && isnan(val) && return oftype(val, u2) # ... (eg when NaN at t1)
     val

--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -5,8 +5,9 @@ function _interpolate(A::LinearInterpolation{<:AbstractVector}, t::Number)
     u1, u2 = A.u[idx], A.u[idx+1]
     θ = (t - t1)/(t2 - t1)
     val = (1 - θ)*u1 + θ*u2
-    t == t1 && return oftype(val, u1) # Return exact value if no interpolation needed (eg when NaN at t2)
-    t == t2 && return oftype(val, u2) # ... (eg when NaN at t1)
+    # Note: The following is limited to when val is NaN as to not change the derivative.
+    t == t1 && isnan(val) && return oftype(val, u1) # Return exact value if no interpolation needed (eg when NaN at t2)
+    t == t2 && isnan(val) && return oftype(val, u2) # ... (eg when NaN at t1)
     val
 end
 

--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -1,13 +1,18 @@
 # Linear Interpolation
+function __interpolate(u1, u2, t1, t2, t)
+    θ = (t - t1)/(t2 - t1)
+    (1 - θ)*u1 + θ*u2
+end
 function _interpolate(A::LinearInterpolation{<:AbstractVector}, t::Number)
     idx = max(1, min(searchsortedlast(A.t, t), length(A.t) - 1))
     t1, t2 = A.t[idx], A.t[idx+1]
     u1, u2 = A.u[idx], A.u[idx+1]
-    t == t1 && return u1 # Return exact value if no interpolation needed (eg when NaN at t2)
-    t == t2 && return u2 # ... (eg when NaN at t1)
-    θ = (t - t1)/(t2 - t1)
-    return (1 - θ)*u1 + θ*u2
-  end
+    # For type stability of fast paths:
+    T = Core.Compiler.return_type(__interpolate, Tuple{typeof(u1), typeof(u2), typeof(t1), typeof(t2), typeof(t)})
+    t == t1 && return T(u1) # Return exact value if no interpolation needed (eg when NaN at t2)
+    t == t2 && return T(u2) # ... (eg when NaN at t1)
+    __interpolate(u1, u2, t1, t2, t)
+end
 
 function _interpolate(A::LinearInterpolation{<:AbstractMatrix}, t::Number)
   idx = max(1, min(searchsortedlast(A.t, t), length(A.t) - 1))

--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -1,8 +1,13 @@
 # Linear Interpolation
 function _interpolate(A::LinearInterpolation{<:AbstractVector}, t::Number)
-    idx = max(1, min(searchsortedlast(A.t, t), length(A.t) - 1))
-    t1, t2 = A.t[idx], A.t[idx+1]
-    u1, u2 = A.u[idx], A.u[idx+1]
+    if isnan(t)
+        t1 = t2 = eltype(A.t)(NaN)
+        u1 = u2 = one(eltype(A.u))
+    else
+        idx = max(1, min(searchsortedlast(A.t, t), length(A.t) - 1))
+        t1, t2 = A.t[idx], A.t[idx+1]
+        u1, u2 = A.u[idx], A.u[idx+1]
+    end
     θ = (t - t1)/(t2 - t1)
     val = (1 - θ)*u1 + θ*u2
     # Note: The following is limited to when val is NaN as to not change the derivative.

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -124,6 +124,12 @@ import ForwardDiff
     A = LinearInterpolation(u, t);
     dA = t -> ForwardDiff.derivative(A, t)
     @test isnan(dA(NaN))
+
+    # Test derivative at point gives derivative to the right (except last is to left):
+    ts = t[begin:end-1]
+    @test dA.(ts) == dA.(ts .+ 0.5)
+    # Test last derivitive is to the left:
+    @test dA(last(t)) == dA(last(t) - 0.5)
 end
 
 @testset "Quadratic Interpolation" begin

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -1,5 +1,6 @@
 using DataInterpolations, Test
 using StableRNGs
+import ForwardDiff
 
 @testset "Linear Interpolation" begin
     u = 2.0collect(1:10)
@@ -110,6 +111,13 @@ using StableRNGs
         @test @inferred(A(R32)) === A(R32)
         @test @inferred(A(R64)) === A(R64)
     end
+
+    # Nan time value:
+    t = 0:3;
+    u = [0, -2, -1, -2];
+    A = LinearInterpolation(u, t);
+    dA = t -> ForwardDiff.derivative(A, t)
+    @test isnan(dA(NaN))
 end
 
 @testset "Quadratic Interpolation" begin

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -85,38 +85,31 @@ using StableRNGs
     # Test type stability
     u = Float32.(1:5)
     t = Float32.(1:5)
-    A = LinearInterpolation(u, t)
-    @test Core.Compiler.return_type(A, Tuple{Float32}) == Float32
-    @test Core.Compiler.return_type(A, Tuple{Float64}) == Float64
-    @test Core.Compiler.return_type(A, Tuple{Int32}) == Float32
-    @test Core.Compiler.return_type(A, Tuple{Int64}) == Float32
-
+    A1 = LinearInterpolation(u, t)
     u = 1:5
     t = 1:5
-    A = LinearInterpolation(u, t)
-    @test Core.Compiler.return_type(A, Tuple{Float32}) == Float32
-    @test Core.Compiler.return_type(A, Tuple{Float64}) == Float64
-    @test Core.Compiler.return_type(A, Tuple{Int32}) == Float64
-    @test Core.Compiler.return_type(A, Tuple{Int64}) == Float64
-
+    A2 = LinearInterpolation(u, t)
     u = [1//i for i in 1:5]
     t = (1:5)
-    A = LinearInterpolation(u, t)
-    @test Core.Compiler.return_type(A, Tuple{Float32}) == Float32
-    @test Core.Compiler.return_type(A, Tuple{Float64}) == Float64
-    @test Core.Compiler.return_type(A, Tuple{Int32}) == Float64
-    @test Core.Compiler.return_type(A, Tuple{Int64}) == Float64
-    @test Core.Compiler.return_type(A, Tuple{Rational{Int64}}) == Rational{Int64}
-
+    A3 = LinearInterpolation(u, t)
     u = [1//i for i in 1:5]
     t = [1//(6-i) for i in 1:5]
-    A = LinearInterpolation(u, t)
-    @test Core.Compiler.return_type(A, Tuple{Float32}) == Float32
-    @test Core.Compiler.return_type(A, Tuple{Float64}) == Float64
-    @test Core.Compiler.return_type(A, Tuple{Int32}) == Rational{Int64}
-    @test Core.Compiler.return_type(A, Tuple{Int64}) == Rational{Int64}
-    @test Core.Compiler.return_type(A, Tuple{Rational{Int32}}) == Rational{Int64}
-    @test Core.Compiler.return_type(A, Tuple{Rational{Int64}}) == Rational{Int64}
+    A4 = LinearInterpolation(u, t)
+
+    F32 = Float32(1)
+    F64 = Float64(1)
+    I32 = Int32(1)
+    I64 = Int64(1)
+    R32 = Int32(1)//Int32(1)
+    R64 = 1//1
+    for A in [A1, A2, A3, A4]
+        @test @inferred(A(F32)) === A(F32)
+        @test @inferred(A(F64)) === A(F64)
+        @test @inferred(A(I32)) === A(I32)
+        @test @inferred(A(I64)) === A(I64)
+        @test @inferred(A(R32)) === A(R32)
+        @test @inferred(A(R64)) === A(R64)
+    end
 end
 
 @testset "Quadratic Interpolation" begin

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -113,7 +113,13 @@ import ForwardDiff
     end
 
     # Nan time value:
-    t = 0:3;
+    t = 0.0:3;  # Floats
+    u = [0, -2, -1, -2];
+    A = LinearInterpolation(u, t);
+    dA = t -> ForwardDiff.derivative(A, t)
+    @test isnan(dA(NaN))
+
+    t = 0:3;  # Integers
     u = [0, -2, -1, -2];
     A = LinearInterpolation(u, t);
     dA = t -> ForwardDiff.derivative(A, t)


### PR DESCRIPTION
The fast path for linear interpolation when no interpolation is needed (time point is provided in vector) returned a different type which caused issues with types/performance with higher level code.

I ran some benchmarks and see no difference in performance.