### PR TITLE
Fix #119 Smooth Akima derivative at end points

### DIFF
--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -119,11 +119,12 @@ function derivative(A::LagrangeInterpolation{<:AbstractMatrix}, t::Number)
 end
 
 function derivative(A::AkimaInterpolation{<:AbstractVector}, t::Number)
+  t < A.t[1] && return zero(A.u[1])
+  t > A.t[end] && return zero(A.u[end])
   i = searchsortedlast(A.t, t)
-  i == 0 && return zero(A.u[1])
-  i == length(A.t) && return zero(A.u[end])
+  j = min(i, length(A.c))  # for smooth derivative at A.t[end]
   wj = t - A.t[i]
-  @evalpoly wj A.b[i] 2A.c[i] 3A.d[i]
+  @evalpoly wj A.b[i] 2A.c[j] 3A.d[j]
 end
 
 function derivative(A::ConstantInterpolation{<:AbstractVector}, t::Number)

--- a/test/derivative_tests.jl
+++ b/test/derivative_tests.jl
@@ -74,6 +74,11 @@ A = AkimaInterpolation(u, t)
 
 test_derivatives(A, t, "Akima Interpolation")
 
+@testset "Akima smooth derivative at end points" begin
+    @test derivative(A, t[1]) ≈ derivative(A, nextfloat(t[1]))
+    @test derivative(A, t[end]) ≈ derivative(A, prevfloat(t[end]))
+end
+
 # QuadraticSpline Interpolation
 u = [0.0, 1.0, 3.0]
 t = [-1.0, 0.0, 1.0]


### PR DESCRIPTION
Without this plotting the derivative looks bad (end point goes to zero) and this seems more correct.