### PR TITLE
Add backward-looking option for quadratic interpolation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataInterpolations"
 uuid = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
-version = "3.9.2"
+version = "3.10.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/example/DataInterpolations.jmd
+++ b/example/DataInterpolations.jmd
@@ -41,11 +41,14 @@ plot!(A)
 
 ### Quadratic Interpolation
 
-This function fits a parabola passing through three nearest points from input
-data point. It is continuous and piecewise differentiable.
+This function fits a parabola passing through the two nearest points from the input
+data point as well as the next-closest point in the right or the left, depending on
+whether the forward- or backward-looking mode is selected (default mode is 
+forward-looking). It is continuous and piecewise differentiable.
 
 ```julia
-A = QuadraticInterpolation(u,t)
+A = QuadraticInterpolation(u,t) # same as QuadraticInterpolation(u,t,:Forward)
+# alternatively: A = QuadraticInterpolation(u,t,:Backward)
 scatter(t, u, label="input data")
 plot!(A)
 ```

--- a/src/interpolation_caches.jl
+++ b/src/interpolation_caches.jl
@@ -14,8 +14,14 @@ end
 struct QuadraticInterpolation{uType,tType,FT,T} <: AbstractInterpolation{FT,T}
   u::uType
   t::tType
-  QuadraticInterpolation{FT}(u,t) where FT = new{typeof(u),typeof(t),FT,eltype(u)}(u,t)
+  mode::Symbol
+  function QuadraticInterpolation{FT}(u,t,mode) where FT
+    mode ∈ (:Forward, :Backward) || error("mode should be :Forward or :Backward for QuadraticInterpolation")
+    new{typeof(u),typeof(t),FT,eltype(u)}(u,t,mode)
+  end
 end
+
+QuadraticInterpolation(u,t) = QuadraticInterpolation(u,t,:Forward)
 
 function QuadraticInterpolation(u,t)
   u, t = munge_data(u, t)

--- a/src/interpolation_caches.jl
+++ b/src/interpolation_caches.jl
@@ -21,12 +21,12 @@ struct QuadraticInterpolation{uType,tType,FT,T} <: AbstractInterpolation{FT,T}
   end
 end
 
-QuadraticInterpolation(u,t) = QuadraticInterpolation(u,t,:Forward)
-
-function QuadraticInterpolation(u,t)
+function QuadraticInterpolation(u,t,mode)
   u, t = munge_data(u, t)
-  QuadraticInterpolation{true}(u,t)
+  QuadraticInterpolation{true}(u,t,mode)
 end
+
+QuadraticInterpolation(u,t) = QuadraticInterpolation(u,t,:Forward)
 
 ### Lagrange Interpolation
 struct LagrangeInterpolation{uType,tType,FT,T,bcacheType} <: AbstractInterpolation{FT,T}

--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -24,9 +24,15 @@ function _interpolate(A::LinearInterpolation{<:AbstractMatrix}, t::Number)
 end
 
 # Quadratic Interpolation
+function _quad_interp_indices(A::QuadraticInterpolation, t::Number)
+  inner_idx = searchsortedlast(A.t, t)
+  A.mode == :Backward && (inner_idx -= 1)
+  idx = max(1, min(inner_idx, length(A.t) - 2))
+  idx, idx + 1, idx + 2
+end
+
 function _interpolate(A::QuadraticInterpolation{<:AbstractVector}, t::Number)
-  idx = max(1, min(searchsortedlast(A.t, t), length(A.t) - 2))
-  i₀, i₁, i₂ = idx, idx + 1, idx + 2
+  i₀, i₁, i₂ = _quad_interp_indices(A, t)
   l₀ = ((t - A.t[i₁])*(t - A.t[i₂]))/((A.t[i₀] - A.t[i₁])*(A.t[i₀] - A.t[i₂]))
   l₁ = ((t - A.t[i₀])*(t - A.t[i₂]))/((A.t[i₁] - A.t[i₀])*(A.t[i₁] - A.t[i₂]))
   l₂ = ((t - A.t[i₀])*(t - A.t[i₁]))/((A.t[i₂] - A.t[i₀])*(A.t[i₂] - A.t[i₁]))
@@ -34,8 +40,7 @@ function _interpolate(A::QuadraticInterpolation{<:AbstractVector}, t::Number)
 end
 
 function _interpolate(A::QuadraticInterpolation{<:AbstractMatrix}, t::Number)
-  idx = max(1, min(searchsortedlast(A.t, t), length(A.t) - 2))
-  i₀, i₁, i₂ = idx, idx + 1, idx + 2
+  i₀, i₁, i₂ = _quad_interp_indices(A, t)
   l₀ = ((t - A.t[i₁])*(t - A.t[i₂]))/((A.t[i₀] - A.t[i₁])*(A.t[i₀] - A.t[i₂]))
   l₁ = ((t - A.t[i₀])*(t - A.t[i₂]))/((A.t[i₁] - A.t[i₀])*(A.t[i₁] - A.t[i₂]))
   l₂ = ((t - A.t[i₀])*(t - A.t[i₁]))/((A.t[i₂] - A.t[i₀])*(A.t[i₂] - A.t[i₁]))

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -146,6 +146,39 @@ end
     @test A(3.5) == 12.25
     @test A(5.0) == 25
 
+    # backward-looking interpolation
+    u = [1.0, 4.0, 9.0, 16.0]
+    t = [1.0, 2.0, 3.0, 4.0]
+    A = QuadraticInterpolation(u,t,:Backward)
+
+    for (_t, _u) in zip(t, u)
+        @test A(_t) == _u
+    end
+    @test A(0.0) == 0.0
+    @test A(1.5) == 2.25
+    @test A(2.5) == 6.25
+    @test A(3.5) == 12.25
+    @test A(5.0) == 25
+
+    
+    u = [1.0, 4.5, 6.0, 2.0]
+    t = [1.0, 2.0, 3.0, 4.0]
+    A_f = QuadraticInterpolation(u,t,:Forward)
+    A_b = QuadraticInterpolation(u,t,:Backward)
+
+    for (_t, _u) in zip(t, u)
+        @test A_f(_t) == _u
+        @test A_b(_t) == _u
+    end
+    l₀, l₁, l₂ = 0.375, 0.75, -0.125
+    # In the first subinterval they're the same (no other option)
+    @test A_f(1.5) == l₀*u[1], l₁*u[2], l₂*u[3]
+    @test A_b(1.5) == l₀*u[1], l₁*u[2], l₂*u[3]
+    # In the second subinterval they should be different
+    @test A_f(2.5) == l₀*u[2], l₁*u[3], l₂*u[4]
+    @test A_b(2.5) == l₂*u[1], l₁*u[2], l₀*u[3]
+
+    # Matrix interpolation test
     u = [1.0 4.0 9.0 16.0; 1.0 4.0 9.0 16.0]
     A = QuadraticInterpolation(u,t)
 

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -172,11 +172,14 @@ end
     end
     l₀, l₁, l₂ = 0.375, 0.75, -0.125
     # In the first subinterval they're the same (no other option)
-    @test A_f(1.5) == l₀*u[1], l₁*u[2], l₂*u[3]
-    @test A_b(1.5) == l₀*u[1], l₁*u[2], l₂*u[3]
+    @test A_f(1.5) ≈ l₀*u[1] + l₁*u[2] + l₂*u[3]
+    @test A_b(1.5) ≈ l₀*u[1] + l₁*u[2] + l₂*u[3]
     # In the second subinterval they should be different
-    @test A_f(2.5) == l₀*u[2], l₁*u[3], l₂*u[4]
-    @test A_b(2.5) == l₂*u[1], l₁*u[2], l₀*u[3]
+    @test A_f(2.5) ≈ l₀*u[2] + l₁*u[3] + l₂*u[4]
+    @test A_b(2.5) ≈ l₂*u[1] + l₁*u[2] + l₀*u[3]
+    # In the last subinterval they should be the same again
+    @test A_f(3.5) ≈ l₂*u[2] + l₁*u[3] + l₀*u[4]
+    @test A_b(3.5) ≈ l₂*u[2] + l₁*u[3] + l₀*u[4]
 
     # Matrix interpolation test
     u = [1.0 4.0 9.0 16.0; 1.0 4.0 9.0 16.0]

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -160,7 +160,7 @@ end
     @test A(3.5) == 12.25
     @test A(5.0) == 25
 
-    
+    # Test both forward and backward-looking quadratic interpolation
     u = [1.0, 4.5, 6.0, 2.0]
     t = [1.0, 2.0, 3.0, 4.0]
     A_f = QuadraticInterpolation(u,t,:Forward)


### PR DESCRIPTION
The current behaviour of QuadraticInterpolation chooses as the three points for the parabolic fit the two closest points to the interpolation point `t`, as well as the next point to the right (whenever possible, since you can't do this for the last subinterval); this is therefore a "forward-looking" behaviour. Another option is just as sensible, a priori: take the previous point to the left whenever possible, representing a "backward-looking" behavior. This PR adds this alternative behaviour as an option, while leaving the forward-looking one as the default if no mode is specified (thus users should see any numerical change at all, unless they explicitly opt in to the backward-looking mode). The proposed interface is 

```julia
I = QuadraticInterpolation(u,t)
I = QuadraticInterpolation(u,t,:Forward) # same outcome as the previous one
I = QuadraticInterpolation(u,t,:Backward)
```

* Personally, I want this feature to be able replicate the behaviour of another package (which implemented it by hand) with DataInterpolations