### PR TITLE
Fix derivatives and integrals for backward QuadraticInterpolation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataInterpolations"
 uuid = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
-version = "3.10.0"
+version = "3.10.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -19,16 +19,7 @@ function derivative(A::LinearInterpolation{<:AbstractMatrix}, t::Number)
 end
 
 function derivative(A::QuadraticInterpolation{<:AbstractVector}, t::Number)
-  idx = searchsortedfirst(A.t, t)
-  if A.t[idx] >= t
-    idx -= 1
-  end
-  idx == 0 ? idx += 1 : nothing
-  if idx == length(A.t) - 1
-    i₀ = idx - 1; i₁ = idx; i₂ = i₁ + 1;
-  else
-    i₀ = idx; i₁ = i₀ + 1; i₂ = i₁ + 1;
-  end
+  i₀, i₁, i₂ = _quad_interp_indices(A, t)
   dl₀ = (2t - A.t[i₁] - A.t[i₂]) / ((A.t[i₀] - A.t[i₁]) * (A.t[i₀] - A.t[i₂]))
   dl₁ = (2t - A.t[i₀] - A.t[i₂]) / ((A.t[i₁] - A.t[i₀]) * (A.t[i₁] - A.t[i₂]))
   dl₂ = (2t - A.t[i₀] - A.t[i₁]) / ((A.t[i₂] - A.t[i₀]) * (A.t[i₂] - A.t[i₁]))

--- a/src/integrals.jl
+++ b/src/integrals.jl
@@ -42,8 +42,10 @@ function _integral(A::ConstantInterpolation{<:AbstractVector}, idx::Number, t::N
   end
 end
 
-samples(A::QuadraticInterpolation{<:AbstractVector}) = (0, 2)
+samples(A::QuadraticInterpolation{<:AbstractVector}) = (0, 1)
 function _integral(A::QuadraticInterpolation{<:AbstractVector{<:Number}}, idx::Number, t::Number)
+  A.mode == :Backward && idx > 1 && (idx -= 1)
+  idx = min(length(A.t) - 2, idx)
   t1 = A.t[idx]
   t2 = A.t[idx+1]
   t3 = A.t[idx+2]

--- a/test/derivative_tests.jl
+++ b/test/derivative_tests.jl
@@ -34,10 +34,29 @@ A = QuadraticInterpolation(u,t)
 
 test_derivatives(A, t, "Quadratic Interpolation (Vector)")
 
+Ab = QuadraticInterpolation(u,t,:Backward)
+
+test_derivatives(Ab, t, "Quadratic Interpolation (Vector), backward")
+
 u = [1.0 4.0 9.0 16.0; 1.0 4.0 9.0 16.0]
 A = QuadraticInterpolation(u,t)
 
 test_derivatives(A, t, "Quadratic Interpolation (Matrix)")
+
+@testset "Backward Quadratic Interpolation" begin
+  u = [1.0, 0.0, 1.0, 0.0]
+  t = [1.0, 2.0, 3.0, 4.0]
+  A_f = QuadraticInterpolation(u,t)
+  A_b = QuadraticInterpolation(u,t,:Backward)
+  @test derivative(A_f, 1.5) ≈ -0.5
+  @test derivative(A_b, 1.5) ≈ -0.5
+  @test derivative(A_f, 2.25) ≈ 0.75
+  @test derivative(A_b, 2.25) ≈ 0.25
+  @test derivative(A_f, 2.75) ≈ 0.25
+  @test derivative(A_b, 2.75) ≈ 0.75
+  @test derivative(A_f, 3.5) ≈ -0.5
+  @test derivative(A_b, 3.5) ≈ -0.5
+end
 
 # Lagrange Interpolation
 u = [1.0, 4.0, 9.0]

--- a/test/derivative_tests.jl
+++ b/test/derivative_tests.jl
@@ -44,7 +44,7 @@ A = QuadraticInterpolation(u,t)
 test_derivatives(A, t, "Quadratic Interpolation (Matrix)")
 
 @testset "Backward Quadratic Interpolation" begin
-  u = [1.0, 0.0, 1.0, 0.0]
+  u = [0.5, 0.0, 0.5, 0.0]
   t = [1.0, 2.0, 3.0, 4.0]
   A_f = QuadraticInterpolation(u,t)
   A_b = QuadraticInterpolation(u,t,:Backward)

--- a/test/integral_tests.jl
+++ b/test/integral_tests.jl
@@ -27,13 +27,35 @@ A = QuadraticInterpolation(u,t)
 
 test_integral(A, t, "Quadratic Interpolation (Vector)")
 
+# Quadratic forward/backward Interpolation
+@testset "QuadraticInterpolation - forward/backward modes" begin
+  u = [3.0, 0.0, 3.0, 0.0]
+  t = [1.0, 2.0, 3.0, 4.0]
+  A_f = QuadraticInterpolation(u,t)
+  A_b = QuadraticInterpolation(u,t,:Backward)
+  @test integral(A_f, 1.0, 2.0) ≈ 1.0
+  @test integral(A_f, 2.0, 3.0) ≈ 2.0
+  @test integral(A_f, 3.0, 4.0) ≈ 2.0
+  @test integral(A_f, 1.0, 3.0) ≈ 3.0
+  @test integral(A_f, 2.0, 4.0) ≈ 4.0
+  @test integral(A_f, 1.0, 4.0) ≈ 5.0
+  @test integral(A_b, 1.0, 2.0) ≈ 1.0
+  @test integral(A_b, 2.0, 3.0) ≈ 1.0
+  @test integral(A_b, 3.0, 4.0) ≈ 2.0
+  @test integral(A_b, 1.0, 3.0) ≈ 2.0
+  @test integral(A_b, 2.0, 4.0) ≈ 3.0
+  @test integral(A_b, 1.0, 4.0) ≈ 4.0
+
+end
+
+
 # QuadraticSpline Interpolation
 u = [0.0, 1.0, 3.0]
 t = [-1.0, 0.0, 1.0]
 
 A = QuadraticSpline(u,t)
 
-test_integral(A, t, "Quadratic Interpolation (Vector)")
+test_integral(A, t, "Quadratic Spline (Vector)")
 
 # CubicSpline Interpolation
 u = [0.0, 1.0, 3.0]


### PR DESCRIPTION
In a [previous PR](https://github.com/PumasAI/DataInterpolations.jl/pull/121), I added a "backward" mode to QuadraticInterpolation, but I unwittingly missed updating derivatives and integrals. This PR fixes that omission by making the derivative() and the integral() consistent with the selected mode (instead of always having the forward-looking behavior).