### PR TITLE
allow array-valued linear interpolation

### DIFF
--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -12,8 +12,8 @@ function _interpolate(A::LinearInterpolation{<:AbstractVector}, t::Number)
     θ = (t - t1)/(t2 - t1)
     val = (1 - θ)*u1 + θ*u2
     # Note: The following is limited to when val is NaN as to not change the derivative of exact points.
-    t == t1 && isnan(val) && return oftype(val, u1) # Return exact value if no interpolation needed (eg when NaN at t2)
-    t == t2 && isnan(val) && return oftype(val, u2) # ... (eg when NaN at t1)
+    t == t1 && any(isnan, val) && return oftype(val, u1) # Return exact value if no interpolation needed (eg when NaN at t2)
+    t == t2 && any(isnan, val) && return oftype(val, u2) # ... (eg when NaN at t1)
     val
 end
 

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -130,6 +130,14 @@ import ForwardDiff
     @test dA.(ts) == dA.(ts .+ 0.5)
     # Test last derivitive is to the left:
     @test dA(last(t)) == dA(last(t) - 0.5)
+
+    # Test array-valued interpolation
+    u = collect.(2.0collect(1:10))
+    t = 1.0collect(1:10)
+    A = LinearInterpolation(u,t)
+    @test A(0)        == fill(0.0)
+    @test A(5.5)      == fill(11.0)
+    @test A(11)       == fill(22)
 end
 
 @testset "Quadratic Interpolation" begin


### PR DESCRIPTION
The check for `nan` prevented me from using matrices as values for the interpolation, this PR allows for that 

`any(isnan, x)` is not slower so the new check should be fine
```
julia> @btime isnan(x) setup=(x=randn())
  1.873 ns (0 allocations: 0 bytes)
false

julia> @btime any(isnan, x) setup=(x=randn())
  1.863 ns (0 allocations: 0 bytes)
false
```