### PR TITLE
Add prefix to extension + add CRC extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,10 +13,12 @@ RegularizationTools = "29dad682-9a27-4bc3-9c72-016788665182"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [weakdeps]
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [extensions]
-SymbolicsExt = "Symbolics"
+DataInterpolationsChainRulesCoreExt = "ChainRulesCore"
+DataInterpolationsSymbolicsExt = "Symbolics"
 
 [compat]
 ChainRulesCore = "0.9.44, 0.10, 1"
@@ -29,6 +31,7 @@ Symbolics = "4"
 julia = "1.6"
 
 [extras]
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
@@ -37,4 +40,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [targets]
-test = ["Test", "StableRNGs", "FiniteDifferences", "QuadGK", "ForwardDiff", "Symbolics"]
+test = ["ChainRulesCore", "Test", "StableRNGs", "FiniteDifferences", "QuadGK", "ForwardDiff", "Symbolics"]

--- a/ext/DataInterpolationsChainRulesCoreExt.jl
+++ b/ext/DataInterpolationsChainRulesCoreExt.jl
@@ -1,0 +1,23 @@
+module DataInterpolationsChainRulesCoreExt
+
+using DataInterpolations: _interpolate, derivative, AbstractInterpolation,
+    LagrangeInterpolation, AkimaInterpolation, BSplineInterpolation, BSplineApprox
+using ChainRulesCore
+
+function ChainRulesCore.rrule(
+    ::typeof(_interpolate),
+    A::Union{LagrangeInterpolation,AkimaInterpolation,BSplineInterpolation,BSplineApprox},
+    t::Number,
+)
+    deriv = derivative(A, t)
+    interpolate_pullback(Δ) = (NoTangent(), NoTangent(), deriv * Δ)
+    return _interpolate(A, t), interpolate_pullback
+end
+
+function ChainRulesCore.frule(
+    (_, _, Δt), ::typeof(_interpolate), A::AbstractInterpolation, t::Number
+)
+    return _interpolate(A, t), derivative(A, t) * Δt
+end
+
+end # module

--- a/ext/DataInterpolationsSymbolicsExt.jl
+++ b/ext/DataInterpolationsSymbolicsExt.jl
@@ -1,4 +1,4 @@
-module SymbolicsExt
+module DataInterpolationsSymbolicsExt
 
 using DataInterpolations: AbstractInterpolation
 using Symbolics: Num, unwrap, SymbolicUtils

--- a/src/DataInterpolations.jl
+++ b/src/DataInterpolations.jl
@@ -13,7 +13,7 @@ Base.setindex!(A::AbstractInterpolation,x,i) = A.u[i] = x
 Base.setindex!(A::AbstractInterpolation{true},x,i) =
     i <= length(A.u) ? (A.u[i] = x) : (A.t[i-length(A.u)] = x)
 
-using ChainRulesCore, LinearAlgebra, RecursiveArrayTools, RecipesBase, Reexport
+using LinearAlgebra, RecursiveArrayTools, RecipesBase, Reexport
 @reexport using Optim
 
 include("interpolation_caches.jl")
@@ -24,20 +24,11 @@ include("derivatives.jl")
 include("integrals.jl")
 include("online.jl")
 
-function ChainRulesCore.rrule(::typeof(_interpolate),
-                              A::Union{LagrangeInterpolation,AkimaInterpolation,
-                                       BSplineInterpolation,BSplineApprox}, t::Number)
-    interpolate_pullback(Δ) = (NoTangent(), NoTangent(), derivative(A, t) * Δ)
-    return _interpolate(A, t), interpolate_pullback
-end
-
-ChainRulesCore.frule((_, _, Δt), ::typeof(_interpolate), A::AbstractInterpolation,
-                     t::Number) = _interpolate(A, t), derivative(A, t) * Δt
-
 (interp::AbstractInterpolation)(t::Number) = _interpolate(interp, t)
 
 if !isdefined(Base, :get_extension)
-    include("../ext/SymbolicsExt.jl")
+    include("../ext/DataInterpolationsChainRulesCoreExt.jl")
+    include("../ext/DataInterpolationsSymbolicsExt.jl")
 end
 
 export LinearInterpolation, QuadraticInterpolation, LagrangeInterpolation,


### PR DESCRIPTION
This PR adds a prefix to the extension (see e.g. https://github.com/JuliaMath/ChangesOfVariables.jl/pull/13 for a motivation). Additionally, it moves the ChainRulesCore definitions to an extension as well, in line with the recent changes in SpecialFunctions, LogExpFunctions etc. 