### PR TITLE
Implement basic `Base.nameof` for interpolations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataInterpolations"
 uuid = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
-version = "3.12"
+version = "3.13"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/ext/DataInterpolationsSymbolicsExt.jl
+++ b/ext/DataInterpolationsSymbolicsExt.jl
@@ -4,5 +4,6 @@ using DataInterpolations: AbstractInterpolation
 using Symbolics: Num, unwrap, SymbolicUtils
 (interp::AbstractInterpolation)(t::Num) = SymbolicUtils.term(interp, unwrap(t))
 SymbolicUtils.promote_symtype(t::AbstractInterpolation, _...) = Real
+Base.nameof(interp::AbstractInterpolation) = :Interpolation
 
 end # module


### PR DESCRIPTION
ModelingToolkit throws errors when trying to print systems with interpolations due to calling `Base.nameof` on expression atoms.