### PR TITLE
remove some unneded strong dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,15 +3,11 @@ uuid = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
 version = "4.0"
 
 [deps]
-ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
-RegularizationTools = "29dad682-9a27-4bc3-9c72-016788665182"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
-Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [weakdeps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"


### PR DESCRIPTION
These are either loaded in 1.9 using the extension system or on 1.8 using Requires. In no case are they needed to be in [deps]. 

This avoids installing these dependencies (and adding them to sysimages) in Julia 1.8.
