### PR TITLE
fix ForwardDiff compatibillity with respect to coefficients

### DIFF
--- a/src/interpolation_caches.jl
+++ b/src/interpolation_caches.jl
@@ -122,7 +122,11 @@ function QuadraticSpline(u::uType,t) where {uType<:AbstractVector{<:Number}}
   d_tmp = ones(eltype(t),s)
   du = zeros(eltype(t),s-1)
   tA = Tridiagonal(dl,d_tmp,du)
-  d = map(i -> i == 1 ? 0 : 2//1 * (u[i] - u[i-1])/(t[i] - t[i-1]), 1:s)
+
+  # zero for element type of d, which we don't know yet
+  typed_zero = zero(2//1 * (u[begin+1] - u[begin])/(t[begin+1] - t[begin]))
+
+  d = map(i -> i == 1 ? typed_zero : 2//1 * (u[i] - u[i-1])/(t[i] - t[i-1]), 1:s)
   z = tA\d
   QuadraticSpline{true}(u,t,tA,d,z)
 end
@@ -158,7 +162,11 @@ function CubicSpline(u::uType,t) where {uType<:AbstractVector{<:Number}}
   d_tmp = 2 .* (h[1:n+1] .+ h[2:n+2])
   du = h[2:n+1]
   tA = Tridiagonal(dl,d_tmp,du)
-  d = map(i -> i == 1 || i == n + 1 ? 0 : 6(u[i+1] - u[i]) / h[i+1] - 6(u[i] - u[i-1]) / h[i], 1:n+1)
+
+  # zero for element type of d, which we don't know yet
+  typed_zero = zero(6(u[begin+2] - u[begin+1]) / h[begin+2] - 6(u[begin+1] - u[begin]) / h[begin+1])
+
+  d = map(i -> i == 1 || i == n + 1 ? typed_zero : 6(u[i+1] - u[i]) / h[i+1] - 6(u[i] - u[i-1]) / h[i], 1:n+1)
   z = tA\d
   CubicSpline{true}(u,t,h[1:n+1],z)
 end

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -531,3 +531,22 @@ A = QuadraticInterpolation(u,t)
 @test A(1.5) == [2.25, 2.25]
 @test A(3.5) == [12.25,12.25]
 @test A(2.5) == [6.25, 6.25]
+
+
+# ForwardDiff compatibility with respect to cofficients
+
+function square(INTERPOLATION_TYPE, c)  # elaborate way to write f(x) = x²
+    xs = 0.0:2.0:4.0
+    ys = [c * x for x in xs]
+    itp = INTERPOLATION_TYPE(ys, xs)
+    return itp(c)
+end
+
+# generate versions of this function with different interpolators
+f_quadratic_spline = c -> square(QuadraticSpline, c)
+f_cubic_spline = c -> square(CubicSpline, c)
+
+@test ForwardDiff.derivative(f_quadratic_spline, -3.0) ≈ -6.0
+@test ForwardDiff.derivative(f_quadratic_spline, 8.0) ≈ 16.0
+@test ForwardDiff.derivative(f_cubic_spline, -3.0) ≈ -6.0
+@test ForwardDiff.derivative(f_cubic_spline, 8.0) ≈ 16.0

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -533,8 +533,8 @@ A = QuadraticInterpolation(u,t)
 @test A(2.5) == [6.25, 6.25]
 
 
-## ForwardDiff compatibility with respect to cofficients
-using Test, DataInterpolations, ForwardDiff
+# ForwardDiff compatibility with respect to cofficients
+
 function square(INTERPOLATION_TYPE, c)  # elaborate way to write f(x) = x²
     xs = -4.0:2.0:4.0
     ys = [c^2 + x for x in xs]

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -533,20 +533,20 @@ A = QuadraticInterpolation(u,t)
 @test A(2.5) == [6.25, 6.25]
 
 
-# ForwardDiff compatibility with respect to cofficients
-
+## ForwardDiff compatibility with respect to cofficients
+using Test, DataInterpolations, ForwardDiff
 function square(INTERPOLATION_TYPE, c)  # elaborate way to write f(x) = x²
-    xs = 0.0:2.0:4.0
-    ys = [c * x for x in xs]
+    xs = -4.0:2.0:4.0
+    ys = [c^2 + x for x in xs]
     itp = INTERPOLATION_TYPE(ys, xs)
-    return itp(c)
+    return itp(0.0)
 end
 
 # generate versions of this function with different interpolators
 f_quadratic_spline = c -> square(QuadraticSpline, c)
 f_cubic_spline = c -> square(CubicSpline, c)
 
-@test ForwardDiff.derivative(f_quadratic_spline, -3.0) ≈ -6.0
-@test ForwardDiff.derivative(f_quadratic_spline, 8.0) ≈ 16.0
-@test ForwardDiff.derivative(f_cubic_spline, -3.0) ≈ -6.0
-@test ForwardDiff.derivative(f_cubic_spline, 8.0) ≈ 16.0
+@test ForwardDiff.derivative(f_quadratic_spline, 2.0) ≈ 4.0
+@test ForwardDiff.derivative(f_quadratic_spline, 4.0) ≈ 8.0
+@test ForwardDiff.derivative(f_cubic_spline, 2.0) ≈ 4.0
+@test ForwardDiff.derivative(f_cubic_spline, 4.0) ≈ 8.0


### PR DESCRIPTION
This PR enables ForwardDiff derivatives of interpolation results with respect to interpolator inputs, i.e.

```julia
using DataInterpolations, ForwardDiff

# elaborate way of writing f(x) = x²
function f(c)
    xs = 0.0:2.0:4.0
    ys = [c * x for x in xs]
    itp = CubicSpline(ys, xs)
    return itp(c)
end

ForwardDiff.derivative(f, 2.0)
```

In the quadratic and cubic spline interpolators, the column vector `d` in the tridiagonal linear solve `tA\d` has element type `Real` when the coefficients are dual types. This happens because the first element of `d` will not be a dual type, due to the edge case.

https://github.com/PumasAI/DataInterpolations.jl/blob/7a4b5f2773b3957ca79adae63bf6dbfd9aee2a2f/src/interpolation_caches.jl#L125

To be as general as possible, this PR determines the type of the *second* element of `d` and then generates a zero element from it. I've included a small regression test.